### PR TITLE
Add reusable parameter and issue fix in the api definition

### DIFF
--- a/certified-connectors/AzureDigitalTwins/apiDefinition.swagger.json
+++ b/certified-connectors/AzureDigitalTwins/apiDefinition.swagger.json
@@ -20,17 +20,10 @@
     "/digitaltwins/{twinid}": {
       "get": {
         "responses": {
-          "default": {
-            "description": "default",
+          "200": {
+            "description": "Success",
             "schema": {
-              "type": "object",
-              "properties": {
-                "result": {
-                  "type": "string",
-                  "description": "Results From the Twin.",
-                  "title": "Result"
-                }
-              }
+              "$ref":"#/definitions/AddTwinResult"
             }
           }
         },
@@ -39,18 +32,10 @@
         "operationId": "GetTwinById",
         "parameters": [
           {
-            "name": "twinid",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/twinid"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "2020-10-31",
-            "x-ms-visibility": "internal"
+            "$ref": "#/parameters/api-version"
           }
         ]
       },
@@ -66,18 +51,10 @@
         "operationId": "DeleteTwin",
         "parameters": [
           {
-            "name": "twinid",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/twinid"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "2020-10-31",
-            "x-ms-visibility": "internal"
+            "$ref": "#/parameters/api-version"
           }
         ]
       },
@@ -92,33 +69,13 @@
         "operationId": "AddTwin",
         "parameters": [
           {
-            "name": "twinid",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/twinid"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "2020-10-31",
-            "x-ms-visibility": "internal"
+            "$ref": "#/parameters/api-version"
           },
           {
-            "name": "Body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "type": "object",
-              "properties": {
-                "value": {
-                  "type": "string",
-                  "description": "Value for the Twin.",
-                  "title": "Value"
-                }
-              }
-            }
+            "$ref": "#/parameters/addValueTemplate"
           }
         ],
         "description": "Creates a new Twin based on the message body."
@@ -135,18 +92,10 @@
         "operationId": "UpdateTwinIntProp",
         "parameters": [
           {
-            "name": "twinid",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/twinid"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "2020-10-31",
-            "x-ms-visibility": "internal"
+            "$ref": "#/parameters/api-version"
           },
           {
             "$ref": "#/parameters/integerUpdate"
@@ -167,18 +116,10 @@
         "operationId": "UpdateTwinStringProp",
         "parameters": [
           {
-            "name": "twinid",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/twinid"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "2020-10-31",
-            "x-ms-visibility": "internal"
+            "$ref": "#/parameters/api-version"
           },
           {
             "$ref": "#/parameters/stringUpdate"
@@ -199,18 +140,10 @@
         "operationId": "UpdateTwinBooleanProp",
         "parameters": [
           {
-            "name": "twinid",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/twinid"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "2020-10-31",
-            "x-ms-visibility": "internal"
+            "$ref": "#/parameters/api-version"
           },
           {
             "$ref": "#/parameters/booleanUpdate"
@@ -221,17 +154,10 @@
     "/digitaltwins/{twinid}/components/{componentPath}": {
       "get": {
         "responses": {
-          "default": {
-            "description": "default",
+          "200": {
+            "description": "Success",
             "schema": {
-              "type": "object",
-              "properties": {
-                "result": {
-                  "type": "string",
-                  "description": "Results From the Twin.",
-                  "title": "Result"
-                }
-              }
+              "$ref": "#/definitions/GetComponentResult"
             }
           }
         },
@@ -240,24 +166,13 @@
         "operationId": "GetComponent",
         "parameters": [
           {
-            "name": "twinid",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/twinid"
           },
           {
-            "name": "componentPath",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/componentPath"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "2020-10-31",
-            "x-ms-visibility": "internal"
+            "$ref": "#/parameters/api-version"
           }
         ]
       },
@@ -273,24 +188,13 @@
         "operationId": "UpdateComponentIntProp",
         "parameters": [
           {
-            "name": "twinid",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/twinid"
           },
           {
-            "name": "componentPath",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/componentPath"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "2020-10-31",
-            "x-ms-visibility": "internal"
+            "$ref": "#/parameters/api-version"
           },
           {
             "$ref": "#/parameters/integerUpdate"
@@ -311,24 +215,13 @@
         "operationId": "UpdateComponentStringProp",
         "parameters": [
           {
-            "name": "twinid",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/twinid"
           },
           {
-            "name": "componentPath",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/componentPath"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "2020-10-31",
-            "x-ms-visibility": "internal"
+            "$ref": "#/parameters/api-version"
           },
           {
             "$ref": "#/parameters/stringUpdate"
@@ -349,24 +242,13 @@
         "operationId": "UpdateComponentBooleanProp",
         "parameters": [
           {
-            "name": "twinid",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/twinid"
           },
           {
-            "name": "componentPath",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/componentPath"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "2020-10-31",
-            "x-ms-visibility": "internal"
+            "$ref": "#/parameters/api-version"
           },
           {
             "$ref": "#/parameters/booleanUpdate"
@@ -388,24 +270,13 @@
         "description": "Retrieve relationship by Twin id.",
         "parameters": [
           {
-            "name": "twinid",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/twinid"
           },
           {
-            "name": "relationshipId",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/relationshipId"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "2020-10-31",
-            "x-ms-visibility": "internal"
+            "$ref": "#/parameters/api-version"
           }
         ],
         "operationId": "GetRelationshipById"
@@ -422,24 +293,13 @@
         "operationId": "DeleteRelationship",
         "parameters": [
           {
-            "name": "twinid",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/twinid"
           },
           {
-            "name": "relationshipId",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/relationshipId"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "2020-10-31",
-            "x-ms-visibility": "internal"
+            "$ref": "#/parameters/api-version"
           }
         ]
       },
@@ -455,39 +315,16 @@
         "operationId": "AddRelationship",
         "parameters": [
           {
-            "name": "twinid",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/twinid"
           },
           {
-            "name": "relationshipId",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/relationshipId"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "2020-10-31",
-            "x-ms-visibility": "internal"
+            "$ref": "#/parameters/api-version"
           },
           {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "type": "object",
-              "properties": {
-                "value": {
-                  "type": "string",
-                  "description": "Value for the Twin.",
-                  "title": "Value"
-                }
-              }
-            }
+            "$ref": "#/parameters/addValueTemplate"
           }
         ]
       },
@@ -500,24 +337,13 @@
         },
         "parameters": [
           {
-            "name": "twinid",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/twinid"
           },
           {
-            "name": "relationshipId",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/relationshipId"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "2020-10-31",
-            "x-ms-visibility": "internal"
+            "$ref": "#/parameters/api-version"
           },
           {
             "$ref": "#/parameters/integerUpdate"
@@ -538,24 +364,13 @@
         },
         "parameters": [
           {
-            "name": "twinid",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/twinid"
           },
           {
-            "name": "relationshipId",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/relationshipId"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "2020-10-31",
-            "x-ms-visibility": "internal"
+            "$ref": "#/parameters/api-version"
           },
           {
             "$ref": "#/parameters/stringUpdate"
@@ -575,24 +390,13 @@
         },
         "parameters": [
           {
-            "name": "twinid",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/twinid"
           },
           {
-            "name": "relationshipId",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/relationshipId"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "2020-10-31",
-            "x-ms-visibility": "internal"
+            "$ref": "#/parameters/api-version"
           },
           {
             "$ref": "#/parameters/booleanUpdate"
@@ -637,18 +441,10 @@
         "description": "Retrieve Incoming Relationships.",
         "parameters": [
           {
-            "name": "twinid",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/twinid"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "2020-10-31",
-            "x-ms-visibility": "internal"
+            "$ref": "#/parameters/api-version"
           }
         ]
       }
@@ -663,18 +459,16 @@
         },
         "parameters": [
           {
-            "name": "twinid",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/twinid"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "2020-10-31",
-            "x-ms-visibility": "internal"
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/messageId"
+          },
+          {
+            "$ref": "#/parameters/telemetrySourceTime"
           },
           {
             "name": "body",
@@ -710,24 +504,19 @@
         "description": "Send Component Telemetry.",
         "parameters": [
           {
-            "name": "twinid",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/twinid"
           },
           {
-            "name": "componentPath",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/componentPath"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "2020-10-31",
-            "x-ms-visibility": "internal"
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/messageId"
+          },
+          {
+            "$ref": "#/parameters/telemetrySourceTime"
           },
           {
             "name": "body",
@@ -775,18 +564,10 @@
         },
         "parameters": [
           {
-            "name": "twinid",
-            "in": "path",
-            "required": true,
-            "type": "string"
+            "$ref": "#/parameters/twinid"
           },
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "2020-10-31",
-            "x-ms-visibility": "internal"
+            "$ref": "#/parameters/api-version"
           }
         ],
         "x-ms-pageable": {
@@ -800,22 +581,10 @@
     "/query": {
       "post": {
         "responses": {
-          "default": {
-            "description": "default",
+          "200": {
+            "description": "Success",
             "schema": {
-              "type": "object",
-              "properties": {
-                "value": {
-                  "type": "string",
-                  "description": "Results From the Twin.",
-                  "title": "Value"
-                },
-                "continuationToken": {
-                  "type": "string",
-                  "description": "Link to get next set of items.",
-                  "title": "Continuation Token"
-                }
-              }
+              "$ref": "#/definitions/QueryResult"
             }
           }
         },
@@ -824,12 +593,7 @@
         "operationId": "QueryTwins",
         "parameters": [
           {
-            "name": "api-version",
-            "in": "query",
-            "required": true,
-            "type": "string",
-            "default": "2020-10-31",
-            "x-ms-visibility": "internal"
+            "$ref": "#/parameters/api-version"
           },
           {
             "name": "body",
@@ -901,6 +665,41 @@
         "additionalProperties": {
           "type": "string",
           "description": "Property Values."
+        }
+      }
+    },
+    "AddTwinResult": {
+      "type": "object",
+      "properties": {
+        "result": {
+          "type": "string",
+          "description": "Results From the Twin.",
+          "title": "Result"
+        }
+      }
+    },
+    "GetComponentResult": {
+      "type": "object",
+      "properties": {
+        "result": {
+          "type": "string",
+          "description": "Results From the Twin.",
+          "title": "Result"
+        }
+      }
+    },
+    "QueryResult": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "Results From the Twin.",
+          "title": "Value"
+        },
+        "continuationToken": {
+          "type": "string",
+          "description": "Link to get next set of items.",
+          "title": "Continuation Token"
         }
       }
     }
@@ -981,6 +780,69 @@
           }
         }
       }
+    },
+    "twinid": {
+      "name": "twinid",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The id of the digital twin. The id is unique within the service and case sensitive.",
+      "x-ms-summary": "Digital twin id"
+    },
+    "api-version": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "default": "2020-10-31",
+      "x-ms-visibility": "internal"
+    },
+    "componentPath": {
+      "name": "componentPath",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The name of the DTDL component.",
+      "x-ms-summary": "DTDL component"
+    },
+    "relationshipId": {
+      "name": "relationshipId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "The id of the relationship. The id is unique within the digital twin and case sensitive.",
+      "x-ms-summary": "Relationship id"
+    },
+    "addValueTemplate":{
+      "name": "Body",
+      "in": "body",
+      "required": true,
+      "schema": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "Value for the Twin.",
+            "title": "Value"
+          }
+        }
+      }
+    },
+    "messageId": {
+      "name": "Message-Id",
+      "in": "header",
+      "required": true,
+      "type": "string",
+      "description": "A unique message identifier (in the scope of the digital twin id) that is commonly used for de-duplicating messages.",
+      "x-ms-summary": "Message id"
+    },
+    "telemetrySourceTime": {
+      "name": "Telemetry-Source-Time",
+      "in": "header",
+      "required": false,
+      "type": "string",
+      "description": "An RFC 3339 timestamp that identifies the time the telemetry was measured.",
+      "x-ms-summary": "Timestamp"
     }
   },
   "responses": {},


### PR DESCRIPTION
## Add reusable parameters and definition

- relationshipId
- componentPath
- twinid
- addValueTemplate
- messageId
- telemetrySourceTime
- AddTwinResult
- GetComponentResult
- QueryResult

## Azure Pipeline Error Fix
Error log link: https://msazure.visualstudio.com/One/_build/results?buildId=60881499&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=7dae026f-9e99-5d65-075e-3f7579577f94&l=20
#### [error]The 'default' response should not have schema definition. Schemas should be defined on expected responses only.
Change response with schema from 'default' to '200' success. 
#### [error]The 'x-ms-summary' property is required. 
#### [error]The 'description' property is required. 
Add description and 'x-ms-summary' for

- relationshipId
- componentPath
- twinid
## Add message id and timestamp for SendTelemetry and SendComponentTelemetry API in the apidefinition file
## Test
Pass all cases in the customer connector test